### PR TITLE
Syntax errors fixed in ECO-Site-full-example.html

### DIFF
--- a/Newsrooms/site level/ECO-Site-full-example.html
+++ b/Newsrooms/site level/ECO-Site-full-example.html
@@ -18,14 +18,14 @@
    "diversityPolicy"                    : "https://www.economist.com/news/21722040-help-shape-how-economist-looks-and-feels-new-digital-platforms-job-listing-social-media-fellow",
    "diversityStaffingReport"            : "",     
    "correctionsPolicy"                  : "http://www.economist.com/contact-info",
-   "ownershipFundingGrants"             : "http://www.economistgroup.com/results_and_governance/ownership.html "
+   "ownershipFundingGrants"             : "http://www.economistgroup.com/results_and_governance/ownership.html",
    "masthead"                           : "http://www.economistgroup.com/results_and_governance/board.html ",
    "missionCoveragePrioritiesPolicy"    : "http://www.economistgroup.com/what_we_do/our_history.html",
    "verificationFactCheckingPolicy"     : "",
    "unnamedSourcesPolicy"               : "", 
    "actionableFeedbackPolicy"           : "", 
    "foundingDate"                       : "1843-02-09",
-   "refLocalNationalRequirements"       : "",
+   "refLocalNationalRequirements"       : ""
   }
   </script>
 


### PR DESCRIPTION
Fixed missed ',' and trimmed extra space that was causing validator errors at [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool). 