### PR TITLE
Update HST-Author-example.html

### DIFF
--- a/Newsrooms/site level/HST-Author-example.html
+++ b/Newsrooms/site level/HST-Author-example.html
@@ -102,7 +102,7 @@ HRST.datalayer = {
         
     },
 
-    "sameAs" : ["https://twitter.com/KSBWChristopher","http://www.ksbw.com/news-team/a95a11dc-f98d-4d2d-9a18-683120f3690"],
+    "sameAs" : ["https://twitter.com/KSBWChristopher","http://www.ksbw.com/news-team/a95a11dc-f98d-4d2d-9a18-683120f36902"],
 	
 	"jobTitle"	: "Anchor/Reporter",    
 


### PR DESCRIPTION
URL for Christopher Salas marked up in sameAs missed a trailing '2' - last character. Broke the URL. Fixed now.