### PR TITLE
Update HST-ToW-example.html

### DIFF
--- a/Newsrooms/PoW level/HST-ToW-example.html
+++ b/Newsrooms/PoW level/HST-ToW-example.html
@@ -149,10 +149,11 @@ HRST.article = {
     "seoTitle": "10 kids, 1 counselor hurt after Jeep rear-ends camp bus",
     "sourceSite": "wcvb"
 };</script><script type="application/json" id="data-layer">{"site":{"name":"WCVB","domain":"wcvb.com","dartZone":"36117602"},"locale":{"language":"en","urlPath":""},"content":{"id":"eb712b22-fd5c-46fc-bd50-68ced62dcbb0","display_id":"11458471","slug":"10-children-hurt-after-jeep-rear-ends-camp-bus","title":"10 kids, 1 counselor hurt after Jeep rear-ends camp bus","publishDate":"2017-08-04T16:06:00Z","createDate":"2017-08-04T16:02:47.167945Z","modifiedDate":"2017-08-04T17:00:14.885013Z","displayType":"Standard Article","sourceName":"Hearst TV","section":{"id":"2d5fc9fe-77de-4f90-8ab3-6465ee715d48","name":"News","slug":"news"},"subsection":{"id":"a0899a99-4450-476c-b300-43a62059151a","name":"Local News","slug":"local-news"},"adCategory":{"id":"","name":"","prefix":""},"embeddedMedia":[],"images":{"lede":{"url":"https://hips.htvapps.com/htv-prod-media.s3.amazonaws.com/images/poster-228-1501862689.jpg","thumb_url":"https://hips.htvapps.com/htv-prod-media.s3.amazonaws.com/images/poster-228-1501862689.jpg?crop=0.565xw:1.00xh;0.218xw,0&resize=100:*","width":1280,"height":720},"social":{"url":"https://hips.htvapps.com/htv-prod-media.s3.amazonaws.com/images/poster-228-1501862689.jpg","thumb_url":"https://hips.htvapps.com/htv-prod-media.s3.amazonaws.com/images/poster-228-1501862689.jpg?crop=0.565xw:1.00xh;0.218xw,0&resize=100:*","width":1280,"height":720}}}}</script>
+
 <script type="application/ld+json" id="json-ld">{
     "@context": "http:\/\/schema.org",
     "url": "http:\/\/www.wcvb.com\/article\/10-children-hurt-after-jeep-rear-ends-camp-bus\/11458471",
-    "@type": "Article",
+    "@type": "ReportageNewsArticle",
     "image": {
         "@type": "ImageObject",
         "url": "https:\/\/hips.htvapps.com\/htv-prod-media.s3.amazonaws.com\/images\/poster-228-1501862689.jpg",
@@ -170,10 +171,12 @@ HRST.article = {
     },
     "author": {
         "@type": "Person",
-        "name": "Hearst Television Inc."
+        "name": "Christopher Salas",
+        "sameAs" : "http://www.ksbw.com/news-team/a95a11dc-f98d-4d2d-9a18-683120f36902"
+        
     },
     "publisher": {
-        "@type": "Organization",
+        "@type": "NewsMediaOrganization",
         "name": "WCVB",
         "logo": {
             "@type": "ImageObject",
@@ -181,22 +184,6 @@ HRST.article = {
         }
     }
 }</script>
-
-<script type="application/ld+json">
-{
-	"@context": "http://schema.org",
-    "@type": "ReportageNewsArticle",
-	"url": "http://www.wcvb.com/article/10-children-hurt-after-jeep-rear-ends-camp-bus/11458471",
-	"publisher": {
-					"@type": "NewsMediaOrganization",
-					"name": "WCVB",
-					"logo": "https://hips.htvapps.com/htv-prod-media.s3.amazonaws.com/htv_default_image/wcvb/logo.png"
-				},
-	"headline": "10 kids, 1 counselor hurt after Jeep rear-ends camp bus'",
-	"mainEntityOfPage": "http://www.wcvb.com/article/10-children-hurt-after-jeep-rear-ends-camp-bus/11458471",
-	"articleBody": "<p>Ten children and one counselor were taken to the hospital Friday with minor injuries after the bus they were riding in was rear-ended in Orleans, according to police. </p><p>A Jeep rear-ended a school bus filled with children going to a camp activity near<br>the intersection of Canal Road and Route 6A, police said. </p><p>Police said the injuries were \"very minor.\"</p>"
-}
-</script>
 
 
 <script id="modernizr-script-tag">/*! modernizr 3.3.1 (Custom Build) | MIT *


### PR DESCRIPTION
This ToW example had @type Article and @type ReportageNewsArticle. Have merged them into ReportageNewsArticle which is the new article subtype for ToW indicator and also replaced @type Organization with NewsMediaOrganization etc. 