### PR TITLE
Update Full-Site-Page-BP-example.html

### DIFF
--- a/TrustProject/Site level/Full-Site-Page-BP-example.html
+++ b/TrustProject/Site level/Full-Site-Page-BP-example.html
@@ -18,31 +18,27 @@
 <!-- Trust Indicator Best Practices Schema.org markup -->
 <!-- WHERE: TBD // home page, about page // THIS IS A MACHINE FOOTER/HEADER OF SORTS -->
 <!-- This is dummy data for illustrative purposes only and not to be construed for real indicators -->
-
+<!-- Note: The following three attributes are to be approved for use in schema.org in release 3.4+ 
+-- "ownershipFundingGrants"	          : "", --
+-- "diversityStaffingReport"            : "", -- 
+--  "refLocalNationalRequirements"       : "", --
+--  The rest below are defined in 3.3 Schema.org release so they are ready for examples
+-->  
+<!-- TRUST PROTOCOL: BEST PRACTICES INDICATOR --> 
 <script type="application/ld+json">
 {
-
-<!-- TRUST PROTOCOL: BEST PRACTICES INDICATOR --> 
-
-"@context"				              : "http://schema.org",
+"@context"				            : "http://schema.org",
 "@type"					              : "NewsMediaOrganization",	
  "name"					              : "Economist",
- "ethicsPolicy"		                  : "http://www.economistgroup.com/results_and_governance/governance/guiding_principles.html",
- "masthead"				              : "http://mediadirectory.economist.com/",
+ "ethicsPolicy"		            : "http://www.economistgroup.com/results_and_governance/governance/guiding_principles.html",
+ "masthead"				            : "http://mediadirectory.economist.com/",
  "missionCoveragePrioritiesPolicy"	  : "http://www.economistgroup.com/what_we_do/our_mission.html",
-
- "diversityPolicy"                    : "",
+  "foundingDate"                       : "1917-07-25", 
+ "diversityPolicy"                  : "",
  "correctionsPolicy"	              : "",
  "verificationFactCheckingPolicy"	  : "",
- "unnamedSourcesPolicy"               : "", 
- "actionableFeedbackPolicy"	          : "", 
- 
- <!-- To be approved for use in schema.org, foundingDate is a property of Organisation --> 
- "foundingDate"                       : "1917-07-25", // To be formalised at schema.org
-
- "ownershipFundingGrants"	          : "http://www.economistgroup.com/results_and_governance/ownership.html",
- "diversityStaffingReport"            : "",
- "refLocalNationalRequirements"       : "",
+ "unnamedSourcesPolicy"             : "", 
+ "actionableFeedbackPolicy"	        : "" 
 }
 </script>
 


### PR DESCRIPTION
To avoid confusion on status of what is spec'd and what is not, Subbu removed three attributes from the current TP BP example that did not catch the schema 3.3 release. We will add these back when 3.4+ catches them. 

- ownershipFundinGrants
- diversityStaffingReport
- refLocalNationalRequirements

Note: foundingDate is already defined as property of Organization and hence usable as markup for NewsMediaOrganization, even we have not formally specified as Trust Markup yet for the BP Founding Date protocol attribute, along with the 3.3 release.