### PR TITLE
Update HST-BestPractices.html

### DIFF
--- a/Newsrooms/site level/HST-BestPractices.html
+++ b/Newsrooms/site level/HST-BestPractices.html
@@ -94,18 +94,12 @@ HRST.datalayer = {
  "ethicsPolicy"		                  : "",
  "masthead"				              : "http://www.kcra.com/news-team",
  "missionCoveragePrioritiesPolicy"	  : "",
-
  "diversityPolicy"                    : "",
  "correctionsPolicy"	              : "",
  "verificationFactCheckingPolicy"	  : "",
  "unnamedSourcesPolicy"               : "", 
  "actionableFeedbackPolicy"	          : "", 
-
-  "foundingDate"                       : "1955-07-01", 
-
- "ownershipFundingGrants"	          : "http://www.hearst.com/newsroom/hearst-television-about-our-company",
- "diversityStaffingReport"            : "",
- "refLocalNationalRequirements"       : ""
+ "foundingDate"                       : "1955-07-01"
 }
 </script>
 


### PR DESCRIPTION
Brought Hearst example in sync with schema 3.3 - removed three attributes that are awaiting spec-ing in schema 3.4+. (ownershipFundingGrants, diversityStaffingReport, refLocalNationalRequirements). 