### PR TITLE
Update and rename Snippet-Citations_References.html to Basic_Snippet-…

### DIFF
--- a/TrustProject/PoW level/Basic_Snippet-Citations_References.html
+++ b/TrustProject/PoW level/Basic_Snippet-Citations_References.html
@@ -17,12 +17,19 @@
 	"headline": "Trump to reinstate US military ban on transgender people",
 	"mainEntityOfPage": "http://www.cnn.com/2017/07/26/politics/trump-military-transgender/index.html",
 	
-	"citation": {
-    "@type": "CreativeWork",
-    "url"  : [
-                "http://www.rand.org/pubs/research_reports/RR1530.html", 
-                "http://www.tandfonline.com/doi/abs/10.1080/1059924X.2015.1000104?journalCode=wagr20",
-                "https://www.cms.gov/CCIIO/Resources/Data-Resources/marketplace-puf.html"]
- } 
+	"citation": [
+	{
+	"@type": "CreativeWork",
+	"url":  "http://www.rand.org/pubs/research_reports/RR1530.html"
+	},
+	{
+ 	"@type": "CreativeWork",
+ 	"url": "http://www.tandfonline.com/doi/abs/10.108/1059924X.2015.1000104?journalCode=wagr20"
+ 	 },
+  	{
+   	 "@type": "CreativeWork", // or just "@type": "CreativeWork"
+   	 "url": "http://www.orlandosentinel.com/news/politics/political-pulse/os-transgender-military-trump-reaction-20170726-story.html"
+  	 }
+ 	]
 }
 </script>


### PR DESCRIPTION
…Citations_References.html

Updated the citations markup from an array of links, with to array of linked marked up with  "CreativeWork". This is now valid for MVP  and is a basic one for newsrooms that don't have a CMS-UX workflow to categorize the citations further internally as documents, datasets, secondary news etc. A separate example will cover the case for newsrooms with that capacity.