### PR TITLE
Update dpa-POW-example.html

### DIFF
--- a/Newsrooms/PoW level/dpa-POW-example.html
+++ b/Newsrooms/PoW level/dpa-POW-example.html
@@ -51,8 +51,6 @@
          "printPage": "",
          "printSection": "",
          "articleSection": "",
-         "publishingPrinciples": 
-"http://www.dpa-international.com/legal/",
          "publisher": {
              "@type": "NewsMediaOrganization",
              "name": "dpa Deutsche Presseagentur",


### PR DESCRIPTION
Removed publishingPrinciples markup going to a URL, since this is now being replaced by the BP individual policy attribute URLs being signaled from the site level. So it will be captured by the platforms there. schema 3.3. has revised the publishingPrinciples property to add the BP policy attributes as its sub-properties and also as sub-properties of NewsMediaOrganization.