### PR TITLE
Update NYT-POW-reviews-single-author.html

### DIFF
--- a/Newsrooms/PoW level/NYT-POW-reviews-single-author.html
+++ b/Newsrooms/PoW level/NYT-POW-reviews-single-author.html
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<!--[if (gt IE 9)|!(IE)]> <!--> <html lang="en" class="no-js section-music format-medium tone-feature app-article page-theme-standard has-top-ad type-size-small has-large-lede" itemid="https://www.nytimes.com/2017/09/06/arts/music/lana-del-rey-lust-for-life-live-review.html" itemtype="http://schema.org/Review"  itemscope xmlns:og="http://opengraphprotocol.org/schema/"> <!--<![endif]-->
+<!--[if (gt IE 9)|!(IE)]> <!--> <html lang="en" class="no-js section-music format-medium tone-feature app-article page-theme-standard has-top-ad type-size-small has-large-lede" itemid="https://www.nytimes.com/2017/09/06/arts/music/lana-del-rey-lust-for-life-live-review.html" itemtype="http://schema.org/ReviewNewsArticle"  itemscope xmlns:og="http://opengraphprotocol.org/schema/"> <!--<![endif]-->
 <!--[if IE 9]> <html lang="en" class="no-js ie9 lt-ie10 section-music format-medium tone-feature app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
 <!--[if IE 8]> <html lang="en" class="no-js ie8 lt-ie10 lt-ie9 section-music format-medium tone-feature app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
 <!--[if (lt IE 8)]> <html lang="en" class="no-js lt-ie10 lt-ie9 lt-ie8 section-music format-medium tone-feature app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
@@ -9,18 +9,20 @@
 <script type="application/ld+json">
     {
         "@context": "http://schema.org",
-        "@type"   : "Person",
-        "name"    : "Jon Caramanica",
-        "description" : "Jon Caramanica is a pop music critic for The New York Times, where he also covers television and writes the men's Critical Shopper column for Styles. After freelancing for the paper, he joined The Times in 2010",
-        "contactPoint"     : {
-            "@type"        : "ContactPoint",
-            "telephone"    : "+1-212-556-1234",
-            "contactType"  : "Public Engagement",
-            "url"          : "https://www.nytimes.com/by/jon-caramanica"
-        },
-        "sameAs" : "https://twitter.com/joncaramanica",
-        "url" : "https://www.nytimes.com/by/jon-caramanica"
+        "@type"   : "ReviewNewsArticle",
+        "author"  : { 
+            "@type"   : "Person",
+            "name"    : "Jon Caramanica",
+            "description" : "Jon Caramanica is a pop music critic for The New York Times, where he also covers television and writes the men's Critical Shopper column for Styles. After freelancing for the paper, he joined The Times in 2010",
+            "contactPoint"     : {
+                "@type"        : "ContactPoint",
+                "telephone"    : "+1-212-556-1234",
+                "contactType"  : "Public Engagement",
+                "url"          : "https://www.nytimes.com/by/jon-caramanica"
+            },
+        "sameAs" : ["https://www.nytimes.com/by/jon-caramanica","https://twitter.com/joncaramanica"]
     }
+  }
 </script>
 <!-- END TRUST INDICATOR -->
 
@@ -484,7 +486,8 @@ data-description="At a show kicking off a handful of concerts supporting her lat
 	                                                <div id="story-meta-footer" class="story-meta-footer">
 
 
-<p class="byline-dateline"><span class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person"  itemid="https://www.nytimes.com/by/jon-caramanica">By <a href="https://www.nytimes.com/by/jon-caramanica" title="More Articles by JON CARAMANICA"><span class="byline-author" data-byline-name="JON CARAMANICA" itemprop="name" data-twitter-handle="joncaramanica">JON CARAMANICA</span></a></span><time class="dateline" datetime="2017-09-06T11:24:51-04:00" itemprop="dateModified" content="2017-09-06T11:24:51-04:00">SEPT. 6, 2017</time>
+<p class="byline-dateline"><span class="byline" itemprop="author creator" itemscope itemtype="http://schema.org/Person"  itemid="https://www.nytimes.com/by/jon-caramanica">By <a href="https://www.nytimes.com/by/jon-caramanica" title="More Articles by JON CARAMANICA"><span class="byline-author" data-byline-name="JON CARAMANICA" itemprop="name" data-twitter-handle="joncaramanica">JON CARAMANICA</span><meta itemprop="sameAs" content="https://www.nytimes.com/by/jon-caramanica"/>
+</a></span><time class="dateline" datetime="2017-09-06T11:24:51-04:00" itemprop="dateModified" content="2017-09-06T11:24:51-04:00">SEPT. 6, 2017</time>
 </p>
 
                                     <div class="story-meta-footer-sharetools">
@@ -1304,7 +1307,7 @@ data-description="At a show kicking off a handful of concerts supporting her lat
          <ul>
              <li>
                 <a href="https://www.nytimes.com/content/help/rights/copyright/copyright-notice.html" itemprop="copyrightNotice">
-                    &copy; <span itemprop="copyrightYear">2017</span><span itemprop="copyrightHolder provider sourceOrganization" itemscope itemtype="http://schema.org/Organization" itemid="http://www.nytimes.com"><span itemprop="name"> The New York Times Company</span><meta itemprop="tickerSymbol" content="NYSE NYT"/></span>
+                    &copy; <span itemprop="copyrightYear">2017</span><span itemprop="copyrightHolder provider sourceOrganization publisher" itemscope itemtype="http://schema.org/NewsMediaOrganization" itemid="http://www.nytimes.com"><span itemprop="name"> The New York Times Company</span><meta itemprop="tickerSymbol" content="NYSE NYT"/></span>
                 </a>
             </li>
             <li class="visually-hidden"><a href="https://www.nytimes.com">Home</a></li>


### PR DESCRIPTION
Made changes to Author and ToW indicators in both JSON-LD and Microdata code to bring this in line with Trust Markup. If the json-LD ContactPoint item can be completely done in Microdata, then we can just as well remove that <script> alone.