### PR TITLE
Update dpa-BP-index-example.html

### DIFF
--- a/Newsrooms/site level/dpa-BP-index-example.html
+++ b/Newsrooms/site level/dpa-BP-index-example.html
@@ -50,8 +50,7 @@
    "unnamedSourcesPolicy"               : "https://dpa-newslab.github.io/tust-project/#sourcing", 
    "actionableFeedbackPolicy"           : "https://dpa-newslab.github.io/tust-project/#feedback", 
    "publicEngagementPolicy"             : "https://dpa-newslab.github.io/tust-project/#engagement", 
-   "foundingDate"                       : "1949-08-18",
-   "refLocalNationalRequirements"       : ""
+   "foundingDate"                       : "1949-08-18"
   }
   </script>
   

--- a/Newsrooms/site level/dpa-BP-index-example.html
+++ b/Newsrooms/site level/dpa-BP-index-example.html
@@ -41,15 +41,12 @@
    "name"                               : "dpa Deutsche Presseagentur",
    "ethicsPolicy"                       : "https://dpa-newslab.github.io/tust-project/#ethics",
    "diversityPolicy"                    : "https://dpa-newslab.github.io/tust-project/#diversity",
-   "diversityStaffingReport"            : "https://dpa-newslab.github.io/tust-project/#diversity",     
    "correctionsPolicy"                  : "https://dpa-newslab.github.io/tust-project/#corrections",
-   "ownershipFundingGrants"             : "https://dpa-newslab.github.io/tust-project/#ownership",
    "masthead"                           : "https://www.dpa.com/en/company/ownership-structure/#editorial-management",
    "missionCoveragePrioritiesPolicy"    : "https://dpa-newslab.github.io/tust-project/#mission",
    "verificationFactCheckingPolicy"     : "https://dpa-newslab.github.io/tust-project/#verification",
    "unnamedSourcesPolicy"               : "https://dpa-newslab.github.io/tust-project/#sourcing", 
    "actionableFeedbackPolicy"           : "https://dpa-newslab.github.io/tust-project/#feedback", 
-   "publicEngagementPolicy"             : "https://dpa-newslab.github.io/tust-project/#engagement", 
    "foundingDate"                       : "1949-08-18"
   }
   </script>


### PR DESCRIPTION
Removed RefLocalNationalRequirements - it's dropped from the indicator and not in schema spec as of now.