### PR TITLE
Update mic-homepage-trust-example.html

### DIFF
--- a/Newsrooms/site level/mic-homepage-trust-example.html
+++ b/Newsrooms/site level/mic-homepage-trust-example.html
@@ -15,10 +15,7 @@
       "verificationFactCheckingPolicy" : "",
       "unnamedSourcesPolicy" : "",
       "actionableFeedbackPolicy" : "",
-      "foundingDate" : "2011-11-23",
-      "ownershipFundingGrants" : "",
-      "diversityStaffingReport" : "",
-      "refLocalNationalRequirements" : ""
+      "foundingDate" : "2011-11-23"
     }
   </script>
   


### PR DESCRIPTION
Removed refLocalNationalRequirements. TTP has dropped that attribute from BP and moved into the main guidance as recommendation. (So need for a signal there.)

Removed attributes ownershipFundingGrants and diversityStaffingReport not yet defined in schema. We will advise on adding them back when spec is out.