### PR TITLE
Update NYT-POW-opinion-no-author.html

### DIFF
--- a/Newsrooms/PoW level/NYT-POW-opinion-no-author.html
+++ b/Newsrooms/PoW level/NYT-POW-opinion-no-author.html
@@ -1,14 +1,23 @@
-
 <!DOCTYPE html>
 <!--[if (gt IE 9)|!(IE)]> <!--> <html lang="en" class="no-js section-opinion format-medium tone-opinion app-article page-theme-standard has-top-ad type-size-small has-large-lede" itemid="https://www.nytimes.com/2017/09/05/opinion/korea-trump.html" itemtype="http://schema.org/OpinionNewsArticle"  itemscope xmlns:og="http://opengraphprotocol.org/schema/"> <!--<![endif]-->
 <!--[if IE 9]> <html lang="en" class="no-js ie9 lt-ie10 section-opinion format-medium tone-opinion app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
 <!--[if IE 8]> <html lang="en" class="no-js ie8 lt-ie10 lt-ie9 section-opinion format-medium tone-opinion app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
 <!--[if (lt IE 8)]> <html lang="en" class="no-js lt-ie10 lt-ie9 lt-ie8 section-opinion format-medium tone-opinion app-article page-theme-standard has-top-ad type-size-small has-large-lede" xmlns:og="http://opengraphprotocol.org/schema/"> <![endif]-->
 <head>
-    <!-- BEGIN TRUST INDICATOR -->
-    <!-- Because there is no Author associated with this article, we have omitted the ld+json blob -->
+<!-- BEGIN TRUST INDICATOR -->
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "OpinionNewsArticle",
+  "mainEntityOfPage": "https://www.nytimes.com/2017/09/05/opinion/korea-trump.html",
+  "author": {
+            "@type"   : "NewsMediaOrganization",
+            "name"    : "New York Times",
+            "sameAs" : ["https://www.facebook.com/nytimes/","https://twitter.com/nytimes", "https://plus.google.com/+TheEconomist"]
+    }
+}
+</script>   
     <!-- END TRUST INDICATOR -->
-
     <title>How to Resolve the North Korea Crisis - The New York Times</title>
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
@@ -104,7 +113,6 @@
 <meta name="dfp-ad-unit-path" content="opinion" />
 <meta name="dfp-amazon-enabled" content="false" />
 <link rel="alternate" type="application/json+oembed" href="https://www.nytimes.com/svc/oembed/json/?url=https%3A%2F%2Fwww.nytimes.com%2F2017%2F09%2F05%2Fopinion%2Fkorea-trump.html" title="How to Resolve the North Korea Crisis" />
-
             <link id="legacy-zam5nzz" rel="stylesheet" type="text/css" href="https://typeface.nyt.com/css/zam5nzz.css" media="all" />
     <!--[if (gt IE 9)|!(IE)]> <!-->
         <link rel="stylesheet" type="text/css" media="screen" href="https://a1.nyt.com/assets/article/20170816-103801/css/article/story/styles.css" />
@@ -119,19 +127,16 @@ var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=i[t];re
 </script>
 <script>NYTD.Abra.init([["www-story-reader-satisfaction",[[21474837,"Control",1],[21474836,"VariantA",1],[4252017623,null,0]]],["www-signup-favor-test",[[2147483648,"0",1],[2147483648,"1",1]]],["www-fixed-nav-subscribe-test",[[4294967296,"1",1]]],["www-ad-diagnostic",[[21474837,"1",0],[4273492459,null,0]]],["www-fabrik-off",[[4294967296,"1",1]]],["www-auto-newsletter",[[4294967296,"1",1]]],["www-STORY_3bundlePayflow-v3",[[2147483648,"control",1],[2147483648,"1",1]]],["Liftoff",[[19520627,"0",1],[19520626,"1",1],[19520627,"2",1],[19520626,"3",1],[19520626,"4",1],[19520627,"5",1],[14839112,"0",1],[14839112,"1",1],[14839112,"2",1],[14839112,"3",1],[14839112,"4",1],[14839112,"5",1],[34359738,"8",1],[34359738,"9",1],[34359739,"12",1],[34359738,"13",1],[34359739,"16",1],[34359738,"17",1],[3882650435,null,0]]],["www-STRIK-nl-regi",[[1434519077,"control",1],[1430224110,"1",1],[1430224109,"2",1],[0,null,0]]],["www-indexAsHeaderBidder",[[4294967296,"2",1]]],["EC_SampleTest",[[2147483648,"variantA",0],[2147483648,"variantB",0]]],["EC_DigiAbandonmentTest",[[4294967296,"sendAbandonmentEmail",1]]],["EC_HdAbandonmentTest",[[4294967296,"sendAbandonmentEmail",1]]],["EC_CrosswordsUpsellTest",[[2147483648,"control",1],[2147483648,"upsell",1]]],["EC_NewSubOnboardingTest",[[2147483648,"control",1],[2147483648,"sov1",1]]],["PaywallAU",[[429496730,"0",1],[3865470566,"1",1]]]], '//et.nytimes.com/')</script>
 <!--  end abra  -->
-
                 <script id="page-config-data" type="text/json">
 {"pageconfig":{"ledeMediaSize":"large","keywords":["Letters","article-medium"],"collections":{"sections":["opinion"]}}}</script>
 <script id="display_overrides">
             []    </script>
-
 			    <script type="text/javascript">
         (function() {
             var s = document.getElementsByTagName("script")[0];
             var mediaDotNet = 'https://contextual.media.net/bidexchange.js?cid=8CU2553YN&amp;https=1';
             var indexBid = 'https://js-sec.indexww.com/ht/p/183760-203795517182556.js';
             var timeout = 300;
-
             function loadScript(tagSrc) {
                 if (tagSrc.substr(0, 4) !== 'http') {
                     var isSSL = 'https:' == document.location.protocol;
@@ -144,28 +149,24 @@ var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=i[t];re
                 scriptTag.src = tagSrc;
                 s.parentNode.insertBefore(scriptTag, s);
             }
-
             function loadGPT() {
                 if (!window.advBidxc.isAdServerLoaded) {
                     loadScript('//www.googletagservices.com/tag/js/gpt.js');
                     window.advBidxc.isAdServerLoaded = true;
                 }
             }
-
             window.advBidxc = window.advBidxc || {};
             window.advBidxc.renderAd = function () {};
             window.advBidxc.startTime = new Date().getTime();
             window.advBidxc.customerId = "8CU2553YN"; //Media.net Customer ID
             window.advBidxc.timeout = 300;
             window.advBidxc.loadGPT = setTimeout(loadGPT, window.advBidxc.timeout);
-
             // append index
             var a = document.createElement("script");
             a.type = "text/javascript";
             a.async = true;
             a.src = indexBid;
             s.parentNode.insertBefore(a, s);
-
             // append media.net
             var b = document.createElement("script");
             b.type = "text/javascript";
@@ -174,7 +175,6 @@ var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=i[t];re
             s.parentNode.insertBefore(b, s);
         })();
     </script>
-
     <!-- A9 Initialization Script -->
     <script type="text/javascript">
         var amznads = amznads || {};
@@ -187,7 +187,6 @@ var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=i[t];re
             },
             'timeout': 1000
         };
-
         (function() {
             var a, s = document.getElementsByTagName("script")[0];
             a = document.createElement("script");
@@ -199,7 +198,6 @@ var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=i[t];re
     </script>
 	<script type="text/json" id="trending-link-json">
 	</script>
-
 <!--esi
 <script id="user-info-data" type="application/json">
 <esi:include src="/svc/web-products/userinfo-v3.json" />
@@ -210,7 +208,6 @@ var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=i[t];re
 (function(){
     if (window.BOOMR && window.BOOMR.version) { return; }
     var dom,doc,where,iframe = document.createElement("iframe"),win = window;
-
     function boomerangSaveLoadTime(e) {
         win.BOOMR_onload=(e && e.timeStamp) || new Date().getTime();
     }
@@ -219,13 +216,11 @@ var NYTD=NYTD||{};NYTD.Abra=function(t){"use strict";function n(t){var n=i[t];re
     } else if (win.attachEvent) {
         win.attachEvent("onload", boomerangSaveLoadTime);
     }
-
     iframe.src = "javascript:void(0)";
     iframe.title = ""; iframe.role = "presentation";
     (iframe.frameElement || iframe).style.cssText = "width:0;height:0;border:0;display:none;";
     where = document.getElementsByTagName("script")[0];
     where.parentNode.insertBefore(iframe, where);
-
     try {
         doc = iframe.contentWindow.document;
     } catch(e) {
@@ -284,24 +279,19 @@ var require = {
     });
     </script>
 </head>
-
 <body>
-
     <style>
     .lt-ie10 .messenger.suggestions {
         display: block !important;
         height: 50px;
     }
-
     .lt-ie10 .messenger.suggestions .message-bed {
         background-color: #f8e9d2;
         border-bottom: 1px solid #ccc;
     }
-
     .lt-ie10 .messenger.suggestions .message-container {
         padding: 11px 18px 11px 30px;
     }
-
     .lt-ie10 .messenger.suggestions .action-link {
         font-family: "nyt-franklin", arial, helvetica, sans-serif;
         font-size: 10px;
@@ -309,7 +299,6 @@ var require = {
         color: #a81817;
         text-transform: uppercase;
     }
-
     .lt-ie10 .messenger.suggestions .alert-icon {
         background: url('https://static01.nyt.com/images/icons/icon-alert-12x12-a81817.png') no-repeat;
         width: 12px;
@@ -318,13 +307,11 @@ var require = {
         margin-top: -2px;
         float: none;
     }
-
     .lt-ie10 .masthead,
     .lt-ie10 .navigation,
     .lt-ie10 .comments-panel {
         margin-top: 50px !important;
     }
-
     .lt-ie10 .ribbon {
         margin-top: 97px !important;
     }
@@ -341,7 +328,6 @@ var require = {
         </div>
     </div>
 </div>
-
     <div id="shell" class="shell">
     <header id="masthead" class="masthead masthead-theme-standard" role="banner">
     <div class="container">
@@ -400,7 +386,6 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
                             </div>
             <div class="field-container">
                                 <input id="search-input" name="search-input" type="text" class="search-input text" autocomplete="off" placeholder="Search NYTimes.com" />
-
                 <button type="button" class="button clear-button" tabindex="-1" aria-describedby="clear-search-input"><i class="icon"></i><span id="clear-search-input" class="visually-hidden">Clear this text input</span></button>
                 <div class="auto-suggest" style="display: none;">
                     <ol></ol>
@@ -410,8 +395,6 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
         </div><!-- close control -->
     </form>
 </nav>
-
-
 </div><!-- close flyout-panel -->
     <div id="notification-modals" class="notification-modals"></div>
 <span class="story-short-url"><a href="https://nyti.ms/2xMqDP7">https://nyti.ms/2xMqDP7</a></span></header>
@@ -438,7 +421,6 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
         </div>
     </div><!-- close nocontent -->
 </nav>
-
 <script type="text/javascript">
 (function () {
     var ribbon;
@@ -457,11 +439,9 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
         <nav id="navigation" class="navigation">
     <h2 class="visually-hidden">Site Navigation</h2>
 </nav><!-- close navigation -->
-
 <nav id="mobile-navigation" class="mobile-navigation hidden">
     <h2 class="visually-hidden">Site Mobile Navigation</h2>
 </nav><!-- close mobile-navigation -->
-
     <div id="navigation-edge" class="navigation-edge"></div>
     <div id="page" class="page">
         <div id="TopAd" class="ad top-ad nocontent robots-nocontent">
@@ -469,13 +449,9 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
     <p>Advertisement</p>
 </div>
 </div>
-
         <main id="main" class="main" role="main">
         <article id="story" class="story theme-main   ">
-
     <div id='TragedyAd' class='ad tragedy-ad nocontent robots-nocontent'></div>
-
-
     <header id="story-header" class="story-header">
                                 <div id="story-meta" class="story-meta ">
                             <div class="supported-by hidden nocontent robots-nocontent">
@@ -487,11 +463,8 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
                                                                             <span class="pipe">|</span>                            <span class="article-kicker">Letters</span><span data-kicker="Letters" class="primer-test"></span>                                                            </h3>
                         			<h1 itemprop="headline" id="headline" class="headline">How to Resolve the North Korea Crisis</h1>
 	                                                <div id="story-meta-footer" class="story-meta-footer">
-
-
 <p class="byline-dateline"><time class="dateline" datetime="2017-09-06T00:27:11-04:00" itemprop="dateModified" content="2017-09-06T00:27:11-04:00">SEPT. 5, 2017</time>
 </p>
-
                                     <div class="story-meta-footer-sharetools">
                         <div id="sharetools-story-meta-footer" aria-label="tools" role="group" class="sharetools theme-classic  sharetools-story-meta-footer  "
 data-shares="facebook,twitter,email,show-all,save"
@@ -512,7 +485,6 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
                             </div><!-- close story-meta-footer -->
         </div><!-- close story-meta -->
     </header>
-
     <script type="text/javascript">
         if (
             window.magnum
@@ -524,8 +496,6 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
             window.magnum.headlineBalancer.initialize();
         }
     </script>
-
-
     <div class="story-body-supplemental">
     <div class="story-body story-body-1">
         <figure id="media-100000005408340" class="media photo lede layout-large-horizontal" data-media-action="modal" itemprop="associatedMedia" itemscope itemid="https://static01.nyt.com/images/2017/09/05/world/05NkoreaSUB/05NkoreaSUB-master768.jpg" itemtype="http://schema.org/ImageObject" aria-label="media" role="group">
@@ -557,7 +527,6 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
             window.NYTD.Abra('www-story-1427-ad-aggro') === 'pro-8' ||
             window.NYTD.Abra('www-story-1427-ad-aggro') === 'pro-6' ||
             window.NYTD.Abra('www-story-1427-ad-aggro') === 'pro-4');
-
         if ((adAggro || adAggro2) &&
             document.documentElement.className.indexOf('article-has-layout-large-horizontal') === -1
         ) {
@@ -576,20 +545,16 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
                             );
                         });
                     });
-
                     return;
                 }
                 document.documentElement.className += ' article-has-layout-large-horizontal';
-
                 // delete supported by
                 supportedBy = document.querySelectorAll('.supported-by')[0];
                 if (supportedBy) {
                         supportedBy.parentNode.removeChild(supportedBy);
                 }
-
                 fragment = document.createDocumentFragment(); // this will be the top ad
                 fragment.appendChild(document.getElementById('TopAd'));
-
                 storyHeader = document.getElementById('story-header');
                 if (storyHeader.nextSibling) {
                   storyHeader.parentNode.insertBefore(fragment, storyHeader.nextSibling);
@@ -597,30 +562,21 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
                 else {
                   storyHeader.parentNode.appendChild(fragment);
                 }
-
                 document.getElementById('TopAd').style.display = 'block';
                 document.getElementById('TopAd').style.marginBottom = '45px';
         } // end ad if
-
-
         if ((adAggro || adAggro2) &&
             document.documentElement.className.indexOf('article-has-layout-large-horizontal') !== -1
         ) {
-
                 html = document.documentElement;
                 header = document.getElementById('story-header');
                 figure = document.querySelectorAll('.lede.photo')[0];
                 headline = document.getElementById('headline');
                 storyMeta = document.getElementById('story-meta');
-
                 mediaActionOverlay = figure.getElementsByClassName("media-action-overlay")[0];
-
                 html.className += ' has-cover-media';
-
                 story.className += " has-headline-image-topper bleed-align-left";
-
                 header.appendChild(figure);
-
             if (window.magnum.getFlags().indexOf('story1427AdAggroTracking') !== -1) {
                 require(['foundation/main'], function (main) {
                     require(['foundation/tracking/tracking-mixin'], function (tracking) {
@@ -635,7 +591,6 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
                     });
                 });
             }
-
         }
 })();
 </script>
@@ -705,12 +660,9 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
 <div id="#continues-post-newsletter"></div>
 <p class="story-body-text story-content" data-para-count="36" data-total-count="2149">DAVID VANSPEYBROECK<br>LAKE OSWEGO, ORE.</p><p class="story-body-text story-content" data-para-count="14" data-total-count="2163"><strong>To the Editor:</strong></p><p class="story-body-text story-content" data-para-count="565" data-total-count="2728">“<a href="https://www.nytimes.com/2017/09/03/us/trump-north-south-korea-nuclear.html">After North Korea Nuclear Test, Trump Saves Harshest Words for South</a>” (news analysis, Sept. 4) offers a thoughtful and rational explanation for the fact that President Trump turned his ire on President Moon Jae-in of South Korea in the hours following North Korea’s successful test of a larger atomic weapon. The article assumes that Mr. Trump’s otherwise foolish attack on our central ally in the region can be explained by his frustration with South Korea’s trade policy and with President Moon’s willingness to try to engage the North Korean regime.</p><p class="story-body-text story-content" data-para-count="436" data-total-count="3164">There may be a simpler explanation. Mr. Trump is frustrated because he can’t simply attack North Korea to settle a score in a conflict with Kim Jong-un, which he himself has clumsily escalated. The more responsible of his advisers surely have pointed out to him that to start a war with North Korea would result in tens of thousands of deaths in Seoul. As a result, Mr. Trump sees South Korea as an inconvenience, and that annoys him.</p><p class="story-body-text story-content" data-para-count="22" data-total-count="3186">JAMES IVY, SAN ANTONIO</p><p class="story-body-text story-content" data-para-count="14" data-total-count="3200"><strong>To the Editor:</strong></p><p class="story-body-text story-content" data-para-count="454" data-total-count="3654">When neither threats nor concessions deter the madman of Pyongyang, it is time for the unthinkable. I do not refer to a pre-emptive strike on North Korea. Rather, let the United States, China, Russia, Japan and South Korea, backed by a unanimous Security Council resolution, offer a huge economic assistance package to the North, contingent upon a large multinational force immediately entering the hermit nation to begin dismantling its nuclear program.</p><p class="story-body-text story-content" data-para-count="185" data-total-count="3839">While near certain to be rejected, such an offer would make unequivocally clear the yawning moral gulf between the welfare of the North Korean people and the war plans of their leaders.</p><p class="story-body-text story-content" data-para-count="26" data-total-count="3865">JEFF FREEMAN, RAHWAY, N.J.</p><footer class="story-footer story-content">
     <div class="story-meta">
-
-
         <p class="story-print-citation">A version of this letter appears in print on September 6, 2017, on Page A22 of the <span itemprop="printEdition">New York edition</span> with the headline: How to Resolve the North Korea Crisis. <span class="story-footer-links">  <span><a href="http://www.nytimes.com/pages/todayspaper/index.html" target="_blank">Today's Paper</a><span class="pipe">|</span></span><span><a href="http://www.nytimes.com/subscriptions/Multiproduct/lp839RF.html?campaignId=48JQY" target="_blank">Subscribe</a></span>
 </span>
 </p>
-
     </div><!-- close story-meta -->
     </footer>
         <a class="visually-hidden skip-to-text-link" href="#whats-next">Continue reading the main story</a>
@@ -718,14 +670,11 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
     <div class="supplemental " id="supplemental-2">
     </div><!-- close supplemental -->
 </div><!-- close story-body-supplemental -->
-
-
     <div class="reader-satisfaction-survey prompt feedback-prompt story-content hidden">
 <a class="feedback-link" href="https://docs.google.com/forms/d/e/1FAIpQLSfLW30xgZodF1qRAg80oWEGuDpW-1HHaL0g42G3SmvB2f4lCw/viewform?entry.8537735=https://www.nytimes.com/2017/09/05/opinion/korea-trump.html" target="_blank">
     <p class="feedback-message">We&#8217;re interested in your feedback on this page. <strong>Tell us what you think.</strong></p>
 </a>
 </div>
-
     <div id="storage-drawer" class="hidden">
         <div class="supplemental-sub-item" data-attribute-position="0" data-attribute-name="PaidPost" data-attribute-type="PaidPost" data-attribute-subtype="">
     <aside id='middle-right-paid-post-container' class='ad middle-right-ad paid-post-ad marginalia-item hidden nocontent robots-nocontent'>
@@ -739,10 +688,7 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
 </aside>
 </div>
     </div>
-
 </article>
-
-
 <aside class="module trending-module hidden nocontent robots-nocontent" data-truncate-enabled="true"></aside><section id="whats-next" class="whats-next nocontent robots-nocontent">
     <h2 class="visually-hidden">What's Next</h2>
     <div class="nocontent robots-nocontent">
@@ -766,336 +712,201 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
         </h2>
         <script>window.magnum.writeLogo('small', 'https://a1.nyt.com/assets/article/20170816-103801/images/foundation/logos/', '', '', 'standard', 'site-index-branding-link', '');</script>
     </header>
-
     <nav id="site-index-navigation" class="site-index-navigation" role="navigation">
         <h2 class="visually-hidden">Site Index Navigation</h2>
         <div class="split-6-layout layout">
-
-
                     <div class="column">
                         <h3 class="menu-heading">News</h3>
                         <ul class="menu">
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/world">World</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/us">U.S.</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/politics">Politics</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/nyregion">N.Y.</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/business">Business</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/technology">Tech</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/science">Science</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/health">Health</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/sports">Sports</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/education">Education</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/obituaries">Obituaries</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/pages/todayspaper/index.html">Today's Paper</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/corrections">Corrections</a>
                                     </li>
-
-
                         </ul>
                     </div><!-- close column -->
-
-
                     <div class="column">
                         <h3 class="menu-heading">Opinion</h3>
                         <ul class="menu">
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/pages/opinion/index.html">Today's Opinion</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/opinion/columnists">Op-Ed Columnists</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/opinion/editorials">Editorials</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/opinion/contributors">Op-Ed Contributors</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/opinion/letters">Letters</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/opinion/sunday">Sunday Review</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/video/opinion">Video: Opinion</a>
                                     </li>
-
-
                         </ul>
                     </div><!-- close column -->
-
-
                     <div class="column">
                         <h3 class="menu-heading">Arts</h3>
                         <ul class="menu">
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/arts">Today's Arts</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/arts/design">Art & Design</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/books">Books</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/arts/dance">Dance</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/movies">Movies</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/arts/music">Music</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/arts/television">Television</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/theater">Theater</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/video/arts">Video: Arts</a>
                                     </li>
-
-
                         </ul>
                     </div><!-- close column -->
-
-
                     <div class="column">
                         <h3 class="menu-heading">Living</h3>
                         <ul class="menu">
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/automobiles">Automobiles</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/crosswords">Crossword</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/pages/dining/index.html">Food</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/education">Education</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/fashion">Fashion & Style</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/health">Health</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/jobs">Jobs</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/magazine">Magazine</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/realestate">Real Estate</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/t-magazine">T Magazine</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/travel">Travel</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/fashion/weddings">Weddings & Celebrations</a>
                                     </li>
-
-
                         </ul>
                     </div><!-- close column -->
-
-
                     <div class="column">
                         <h3 class="menu-heading">Listings & More</h3>
                         <ul class="menu">
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/reader-center">Reader Center</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/ref/classifieds/">Classifieds</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/marketing/tools-and-services/">Tools & Services</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/events/">N.Y.C. Events Guide</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/section/multimedia">Multimedia</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://lens.blogs.nytimes.com/">Photography</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/video">Video</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/store/?&t=qry542&utm_source=nytimes&utm_medium=HPB&utm_content=hp_browsetree&utm_campaign=NYT-HP&module=SectionsNav&action=click&region=TopBar&version=BrowseTree&contentCollection=NYT%20Store&contentPlacement=2&pgtype=Homepage">NYT Store</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/times-journeys/?utm_source=nytimes&utm_medium=HPLink&utm_content=hp_browsetree&utm_campaign=NYT-HP">Times Journeys</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/seeallnav">Subscribe</a>
                                     </li>
-
-
                                     <li>
                                         <a href="https://www.nytimes.com/membercenter">Manage My Account</a>
                                     </li>
-
-
                                     <li>
                                         <a href="http://www.nytco.com">NYTCo</a>
                                     </li>
-
-
                         </ul>
                     </div><!-- close column -->
-
-
             <div class="column last-column">
-
 <h3 class="menu-heading">Subscribe</h3>
-
 <ul class="menu primary-menu">
     <li class="menu-label">Subscribe</li>
     <li class="home-delivery">
@@ -1111,9 +922,7 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
         <a id="nyt-crossword" href="https://www.nytimes.com/crosswords/index.html">Crossword</a>
     </li>
 </ul>
-
 <ul class="menu secondary-menu">
-
     <li class="email-newsletters">
         <a href="https://www.nytimes.com/marketing/newsletters">Email Newsletters</a>
     </li>
@@ -1129,7 +938,6 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
     <li>
                     <a href="https://www.nytimes.com/educationleftnav">Education Rate</a>
             </li>
-
 </ul>
 <ul class="menu secondary-menu">
     <li>
@@ -1138,24 +946,18 @@ data-description="Readers offer their ideas, including a peace treaty, ignoring 
     <li>
                     <a href="http://eedition.nytimes.com/cgi-bin/signup.cgi?cc=37FYY">Replica Edition</a>
             </li>
-
 </ul>
-
             </div><!-- close column -->
-
         </div><!-- close split-6-layout -->
-
     </nav><!-- close nav -->
-
 </section><!-- close site-index -->
-
             <footer id="page-footer" class="page-footer" role="contentinfo">
     <nav>
         <h2 class="visually-hidden">Site Information Navigation</h2>
          <ul>
              <li>
                 <a href="https://www.nytimes.com/content/help/rights/copyright/copyright-notice.html" itemprop="copyrightNotice">
-                    &copy; <span itemprop="copyrightYear">2017</span><span itemprop="copyrightHolder provider sourceOrganization" itemscope itemtype="http://schema.org/Organization" itemid="http://www.nytimes.com"><span itemprop="name"> The New York Times Company</span><meta itemprop="tickerSymbol" content="NYSE NYT"/></span>
+                    &copy; <span itemprop="copyrightYear">2017</span><span itemprop="copyrightHolder provider sourceOrganization publisher" itemscope itemtype="http://schema.org/NewsMediaOrganization" itemid="http://www.nytimes.com"><span itemprop="name"> The New York Times Company</span><meta itemprop="tickerSymbol" content="NYSE NYT"/></span>
                 </a>
             </li>
             <li class="visually-hidden"><a href="https://www.nytimes.com">Home</a></li>
@@ -1201,7 +1003,6 @@ require(['foundation/main'], function () {
 <!--esi
 <esi:include src="/appconfig/https/show-modal.js" />
 -->
-
     <div id="Inv1" class="ad inv1-ad hidden"></div>
 <div id="Inv2" class="ad inv2-ad hidden"></div>
 <div id="Inv3" class="ad inv3-ad hidden"></div>

--- a/Newsrooms/PoW level/NYT-POW-opinion-no-author.html
+++ b/Newsrooms/PoW level/NYT-POW-opinion-no-author.html
@@ -13,7 +13,7 @@
   "author": {
             "@type"   : "NewsMediaOrganization",
             "name"    : "New York Times",
-            "sameAs" : ["https://www.facebook.com/nytimes/","https://twitter.com/nytimes", "https://plus.google.com/+TheEconomist"]
+            "sameAs" : ["https://www.facebook.com/nytimes/","https://twitter.com/nytimes","https://plus.google.com/+nytimes"]
     }
 }
 </script>   


### PR DESCRIPTION
I have added the basic Organization-is-author schema to this piece. This is similar to the Economist PoW example, since their pieces don't have author names. 

There is a deeper no-byline, brand-author exception schema pending discussion at schema.org. When that gets into a schema release spec, we will be able to markup a few more properties and values. We can update this example after that afresh. 

For now this is ready to send for testing after review by an NYT developer. 