### PR TITLE
Update ECO-Site-full-example.html

### DIFF
--- a/Newsrooms/site level/ECO-Site-full-example.html
+++ b/Newsrooms/site level/ECO-Site-full-example.html
@@ -16,16 +16,13 @@
    "name"                               : "The Economist",
    "ethicsPolicy"                       : "http://www.economistgroup.com/results_and_governance/governance/guiding_principles.html",
    "diversityPolicy"                    : "https://www.economist.com/news/21722040-help-shape-how-economist-looks-and-feels-new-digital-platforms-job-listing-social-media-fellow",
-   "diversityStaffingReport"            : "",     
    "correctionsPolicy"                  : "http://www.economist.com/contact-info",
-   "ownershipFundingGrants"             : "http://www.economistgroup.com/results_and_governance/ownership.html",
    "masthead"                           : "http://www.economistgroup.com/results_and_governance/board.html ",
    "missionCoveragePrioritiesPolicy"    : "http://www.economistgroup.com/what_we_do/our_history.html",
    "verificationFactCheckingPolicy"     : "",
    "unnamedSourcesPolicy"               : "", 
    "actionableFeedbackPolicy"           : "", 
-   "foundingDate"                       : "1843-02-09",
-   "refLocalNationalRequirements"       : ""
+   "foundingDate"                       : "1843-02-09"
   }
   </script>
 


### PR DESCRIPTION
Removed refLocalNationalRequirements - this attribute has been removed from the main protocol signals and moved into general guidance. (See indicator guidance doc) 
Also removed ownershipFundingGrants and diversityStaffingReport - this is still pending next release of schema.org. We can add these back with the final exact property names once we get the release. Nothing to worry.