### PR TITLE
Update GAM-BP-aboutus.html

### DIFF
--- a/Newsrooms/site level/GAM-BP-aboutus.html
+++ b/Newsrooms/site level/GAM-BP-aboutus.html
@@ -6174,16 +6174,13 @@
       ],
       "ethicsPolicy":"https://www.theglobeandmail.com/incoming/article10200488.ece/BINARY/Editorial+Code+Book+External.pdf",
       "diversityPolicy":"",
-      "diversityStaffingReport":"",
       "correctionsPolicy":"https://www.theglobeandmail.com/incoming/article10200488.ece/BINARY/Editorial+Code+Book+External.pdf",
-      "ownershipFundingGrants":"",
       "masthead":"",
       "missionCoveragePrioritiesPolicy":"https://www.theglobeandmail.com/incoming/article10200488.ece/BINARY/Editorial+Code+Book+External.pdf",
       "verificationFactCheckingPolicy":"https://www.theglobeandmail.com/incoming/article10200488.ece/BINARY/Editorial+Code+Book+External.pdf",
       "unnamedSourcesPolicy":"https://www.theglobeandmail.com/incoming/article10200488.ece/BINARY/Editorial+Code+Book+External.pdf",
       "actionableFeedbackPolicy":"https://www.theglobeandmail.com/incoming/article10200488.ece/BINARY/Editorial+Code+Book+External.pdf",
-      "foundingDate":"1844",
-      "refLocalNationalRequirements":""
+      "foundingDate":"1844"
     }
     </script>
 </body>


### PR DESCRIPTION
Housekeeping update - removed ownershipFundingGrants and diversityStaffingReport to keep snippet on spec. These were not in the schema.org 3.3 release. Will catch them back up when the spec is out. 

Also removed refLocalNationalRequirements. It's not in the protocol signal much anymore.