### PR TITLE
Update ECO-Site-full-example.html

### DIFF
--- a/Newsrooms/site level/ECO-Site-full-example.html
+++ b/Newsrooms/site level/ECO-Site-full-example.html
@@ -24,8 +24,7 @@
    "verificationFactCheckingPolicy"     : "",
    "unnamedSourcesPolicy"               : "", 
    "actionableFeedbackPolicy"           : "", 
-   "foundingDate"                       : "1843-02-09",
-   "refLocalNationalRequirements"       : ""
+   "foundingDate"                       : "1843-02-09"
   }
   </script>
 


### PR DESCRIPTION
Removed refLocalNationalRequirements - this attribute has been taken out of BP attributes for machine signals and moved into general guidance. 