### PR TITLE
Trust author ref. snippet with contactType change

### DIFF
--- a/TrustProject/Site level/Snippet-Author-Info.html
+++ b/TrustProject/Site level/Snippet-Author-Info.html
@@ -28,7 +28,7 @@
     "contactPoint"     : {
         "@type"        : "ContactPoint",
        	"telephone"    : "+1-425-123-4567",
-        "contactType"  : "Public Engagement",
+        "contactType"  : "Journalist",
         "email"        : "maggieh@nytco.com",
         "url"          : "http://www.nytimes.com/help/index.html" 
     },


### PR DESCRIPTION
We've gotten clearance to use three different contactType text strings for each of the three different contact points used in the Trust indicator set. (Two BP contacts and one author). 

For author, the contactType will be "Journalist".