### PR TITLE
Update ORB-Author-Example

### DIFF
--- a/Newsrooms/site level/ORB-Author-Example
+++ b/Newsrooms/site level/ORB-Author-Example
@@ -4,6 +4,7 @@
     "@type": "Person",
     "name": "Dan Morrison",
     "url": "https://orbmedia.org/what-we-do#danmorrison",
+    "sameAs": ["https://orbmedia.org/what-we-do#danmorrison","put Dan Morrison twitter ID here"],
     "image": "https://orbmedia.org/sites/default/files/styles/square/public/DM%20headshot%20007.png?itok=fLe0VfOX",
     "description": "Former staff writer and correspondent at Newsday; former staff writer, Bloomberg News; have written about South Asia and Africa as a frequent contributor to National Geographic (online) and The New York Times (print and online). Other outlets include Slate, the Christian Science Monitor, San Francisco Chronicle, Politico Magazine, Artforum. Author of \"The Black Nile\" (VIking, 2010), named one of the Village Voice's ten best books of the year, with strong favorable reviews in the Wall Street Journal, The New York Times, Los Angeles Times, Washington Post, and the Daily Beast. Have been quoted in the New York Times as a subject matter expert on conflict over the Nile River, and in the Times of London as an expert on efforts to restore the Ganges River. Amateur historian of cholera and plague in India.",
     "identifier": "",

--- a/Newsrooms/site level/ORB-Author-Example
+++ b/Newsrooms/site level/ORB-Author-Example
@@ -3,15 +3,21 @@
     "@context": "http://schema.org",
     "@type": "Person",
     "name": "Dan Morrison",
-    "url": "https://orbmedia.org/what-we-do#danmorrison”,
+    "url": "https://orbmedia.org/what-we-do#danmorrison",
     "image": "https://orbmedia.org/sites/default/files/styles/square/public/DM%20headshot%20007.png?itok=fLe0VfOX",
-    "description": "Former staff writer and correspondent at Newsday; former staff writer, Bloomberg News; have written about South Asia and Africa as a frequent contributor to National Geographic (online) and The New York Times (print and online). Other outlets include Slate, the Christian Science Monitor, San Francisco Chronicle, Politico Magazine, Artforum. Author of "The Black Nile" (VIking, 2010), named one of the Village Voice's ten best books of the year, with strong favorable reviews in the Wall Street Journal, The New York Times, Los Angeles Times, Washington Post, and the Daily Beast. Have been quoted in the New York Times as a subject matter expert on conflict over the Nile River, and in the Times of London as an expert on efforts to restore the Ganges River. Amateur historian of cholera and plague in India.",
+    "description": "Former staff writer and correspondent at Newsday; former staff writer, Bloomberg News; have written about South Asia and Africa as a frequent contributor to National Geographic (online) and The New York Times (print and online). Other outlets include Slate, the Christian Science Monitor, San Francisco Chronicle, Politico Magazine, Artforum. Author of \"The Black Nile\" (VIking, 2010), named one of the Village Voice's ten best books of the year, with strong favorable reviews in the Wall Street Journal, The New York Times, Los Angeles Times, Washington Post, and the Daily Beast. Have been quoted in the New York Times as a subject matter expert on conflict over the Nile River, and in the Times of London as an expert on efforts to restore the Ganges River. Amateur historian of cholera and plague in India.",
     "identifier": "",
     "jobTitle": "Reporter",
-    "workLocation": {
+    "workLocation": [
+        {
         "@type": "Place",
-        "name": “India / USA”
-    },
+        "name": "New Delhi, NCT, India"
+        }, 
+        {
+        "@type": "Place",
+        "name": "New York, New York, USA"    
+        }
+    ],
     "contactPoint": {
         "@type": "ContactPoint",
         "contactType": "Journalist",
@@ -21,11 +27,11 @@
     "affiliation": [
         {
             "@type": "NewsMediaOrganization",
-            "name": “Orb Media“,
+            "name": "Orb Media",
             "url": "https://orbmedia.org/",
             "parentOrganization": {
                 "@type": "NewsMediaOrganization",
-                "name": “Orb Media”,
+                "name": "Orb Media",
                 "logo": {
                     "@type": "ImageObject",
                     "url": "https://orbmedia.org/sites/all/themes/orbmedia/css/images/logo.png",
@@ -36,11 +42,11 @@
         }
     ],
     "award": [
-        “2017 - Reader’s Choice - Top Deutsche Welle Environmental Stories",
+        "2017 - Reader’s Choice - Top Deutsche Welle Environmental Stories",
         "2014 - Commentary Finalist, South Asian Journalists Association Awards (New York Times)",
         "2013 - Commentary Finalist, South Asian Journalists Association Awards (Al Jazeera English)",
-        "2013 - Global Health Fellow, United Nations Foundation (India and Malawi)”,
-        “2013 - Grantee, Solutions Journalism Network (Bangladesh)",
+        "2013 - Global Health Fellow, United Nations Foundation (India and Malawi)",
+        "2013 - Grantee, Solutions Journalism Network (Bangladesh)",
         "2012 - Global Issues Journalism Fellow, United Nations Foundation",
         "1996-1999 - Awards from the Deadline Club, Society of Silurians, and New York Association of Black Journalists for investigations and breaking news reporting in Newsday"
     ],
@@ -88,7 +94,7 @@
     "knowsLanguage": [
         {
             "@type": "Language",
-            "name": “English”,
+            "name": "English",
             "sameAs": "https://www.wikidata.org/wiki/Q1860"
         }
     ]


### PR DESCRIPTION
Revised workLocation markup to make it compliant to the 'comma separated place name text format', and added an example of a dual-located author.

Also the Google validator breaks heavily on minor differences in quotation marks.

" - works
” - does not! 

So I fixed those. 